### PR TITLE
feat: add support for s3-like filesystems

### DIFF
--- a/mongo2pq/main.py
+++ b/mongo2pq/main.py
@@ -17,7 +17,7 @@ from mongo2pq.schema import infer_schema, load_schema_from_file
 def main(
     uri: str, *,
     db: str | None = None, collections: List[str] | None = None,
-    outdir: Path = Path('.'),
+    outdir = '.',
     schema_paths: List[Path] | None = None, samples: int = 20000,
     partition_key: str | None = None, config_file: Path | None = None,
     debug_config: bool = False, cli: bool = True
@@ -109,8 +109,8 @@ def parse_args() -> Namespace | None:
     )
     parser.add_argument(
         '-o', '--outdir',
-        default='./', type=Path,
-        help="Destination for the output parquet files and schema files"
+        default='./',
+        help="Destination for the output parquet files and schema files. Can be a local folder or an URI like s3://, hdfs://, gcs://... as long as it's supported by PyArrow"
     )
     parser.add_argument(
         '-s', '--samples',


### PR DESCRIPTION
I need to save to S3, so rather than first saving to the local filesystem and then copying to S3, this allows setting S3 (or a similar file system supported by PyArrow) as destination.